### PR TITLE
Markdownify footnote bodies

### DIFF
--- a/lib/jekyll/footnotes.rb
+++ b/lib/jekyll/footnotes.rb
@@ -60,7 +60,9 @@ module Jekyll
     def render(context)
       context.stack do
         body = super
-        "<ol class=\"footnotelist\">#{body}</ol>"
+        site = context.registers[:site]
+        converter = site.getConverterImpl(Jekyll::Converters::Markdown)
+        "<ol class=\"footnotelist\">#{converter.convert(body)}</ol>"
       end
     end
   end


### PR DESCRIPTION
Use the Jekyll Markdown converter when printing the body of footnotes so
that links and other Markdown syntax can be used.
